### PR TITLE
Adds catkin_INCLUDE_DIRS to include_directories

### DIFF
--- a/gcloud_speech/CMakeLists.txt
+++ b/gcloud_speech/CMakeLists.txt
@@ -76,8 +76,11 @@ generate_proto(googleapis_speech_proto GRPC ${GOOGLEAPIS_SPEECH_PROTOS})
 generate_proto(cogrob_gcloud_speech_proto
   SRC_BASE src/workspace
   src/workspace/cogrob/cloud/speech/proto/recognition_result.proto)
+
+include_directories(${catkin_INCLUDE_DIRS})
 include_directories(src/workspace)
 include_directories(src/googleapis_include)
+
 add_library(gcloud_speech_lib
   src/workspace/util/statusor.cc
   src/workspace/util/status.cc

--- a/gcloud_speech_utils/CMakeLists.txt
+++ b/gcloud_speech_utils/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin
 
 catkin_package()
 
+include_directories(${catkin_INCLUDE_DIRS})
 include_directories(src/workspace)
 
 add_library(gcloud_speech_utils_record_audio_lib


### PR DESCRIPTION
Fixes an issue that missing include_directories(${catkin_INCLUDE_DIRS}) causing Kinetic build fails.

http://build.ros.org/job/Kbin_uX64__gcloud_speech__ubuntu_xenial_amd64__binary/1/consoleFull